### PR TITLE
Suppress `curl`-output and show what's currently downloaded on stderr

### DIFF
--- a/lib/hydra/fetch.rb
+++ b/lib/hydra/fetch.rb
@@ -9,7 +9,8 @@ module Hydra::Fetch
     filename = cache_key
 
     unless File.exists?(filename)
-      `curl -o "#{filename}" "#{url}"`
+      STDERR.puts "Downloading #{url}..."
+      `curl -s -o "#{filename}" "#{url}"`
     end
 
     File.read(filename)


### PR DESCRIPTION
When generating reports for rather big jobsets (with many failures), the
progress-bar from curl isn't very helpful and IMHO rather distracting.

This change sets `curl` into silent-mode and prints to stderr what file
is about to get downloaded.